### PR TITLE
Fix broken link on "Creating Networks" page

### DIFF
--- a/docs/Creating_Networks.md
+++ b/docs/Creating_Networks.md
@@ -14,10 +14,9 @@ There are 4 different ways of creating networks in Cytoscape:
 <a id="import_fixed_format_network_files"> </a>
 ## Import Fixed-Format Network Files
 
-Network files can be specified in any of the formats described in the
-**[Supported Network
-Formats](Supported_Network_File_Formats.html#supported-network-file-formats)**
-section. Networks are imported into Cytoscape via **File →
+Network files can be specified in any of the formats described on the
+**[Supported Network Formats](Supported_Network_File_Formats.html)**
+page. Networks are imported into Cytoscape via **File →
 Import**. The network file can either be located directly
 on the local computer, or found on a remote computer (in which case it
 will be referenced with a URL).


### PR DESCRIPTION
Currently http://manual.cytoscape.org/en/3.7.1/Creating_Networks.html has a dead link in the first paragraph (5.1) to http://manual.cytoscape.org/en/3.7.1/Supported_Network_File_Formats.md#supported-network-file-formats

This is probably meant to be to page http://manual.cytoscape.org/en/3.7.1/Supported_Network_File_Formats.html (as per this pull request), or perhaps the section lower down, http://manual.cytoscape.org/en/3.7.1/Creating_Networks.html#supported-files