### PR TITLE
Update the Supported Network File page.

### DIFF
--- a/docs/Supported_Network_File_Formats.md
+++ b/docs/Supported_Network_File_Formats.md
@@ -49,12 +49,12 @@ layout of the network each time it is loaded.
 Lines in the SIF file specify a source node, a relationship type (or
 edge type), and one or more target nodes:
 
-    nodeA &lt;relationship type&gt; nodeB
-    nodeC &lt;relationship type&gt; nodeA
-    nodeD &lt;relationship type&gt; nodeE nodeF nodeB
+    nodeA relationship_type nodeB
+    nodeC relationship_type nodeA
+    nodeD relationship_type nodeE nodeF nodeB
     nodeG
     ...
-    nodeY &lt;relationship type&gt; nodeZ
+    nodeY relationship_type nodeZ
 
 A more specific example is:
 
@@ -74,9 +74,9 @@ node that has no relationships with other nodes. This form is not needed
 for nodes that do have relationships, since the specification of the
 relationship implicitly identifies the nodes as well.
 
-Duplicate entries are ignored. Multiple edges between the same nodes
-must have different edge types. For example, the following specifies two
-edges between the same pair of nodes, one of type xx and one of type yy:
+Duplicate entries are kept. Multiple edges between the same nodes
+can have the same edge types. For example, the following specifies three
+edges between the same pair of nodes, two of type xx and one of type yy:
 
     node1 xx node2
     node1 xx node2

--- a/docs/Supported_Network_File_Formats.md
+++ b/docs/Supported_Network_File_Formats.md
@@ -49,12 +49,12 @@ layout of the network each time it is loaded.
 Lines in the SIF file specify a source node, a relationship type (or
 edge type), and one or more target nodes:
 
-    nodeA <relationship type> nodeB
-    nodeC <relationship type> nodeA
-    nodeD <relationship type> nodeE nodeF nodeB
+    nodeA &lt;relationship type&gt; nodeB
+    nodeC &lt;relationship type&gt; nodeA
+    nodeD &lt;relationship type&gt; nodeE nodeF nodeB
     nodeG
     ...
-    nodeY <relationship type> nodeZ
+    nodeY &lt;relationship type&gt; nodeZ
 
 A more specific example is:
 

--- a/docs/Supported_Network_File_Formats.md
+++ b/docs/Supported_Network_File_Formats.md
@@ -6,6 +6,11 @@ Cytoscape represents networks as directed graphs, where nodes represent entities
 Cytoscape can read network/pathway files written in the following
 formats:
 
+-   Cytoscape Exchange Format (CX2)    
+
+-   [Cytoscape.js
+    JSON](http://cytoscape.github.io/cytoscape.js/#notation/elements-json)
+
 -   Simple interaction file (SIF or .sif format)
 
 -   Graph Markup Language (GML or .gml format)
@@ -21,202 +26,66 @@ formats:
 -   Delimited text
 
 -   Excel Workbook (.xls, .xlsx)
-
--   [Cytoscape.js
-    JSON](http://cytoscape.github.io/cytoscape.js/#notation/elements-json)
     
--   Cytoscape Exchange Format (CX2)    
 
 These formats vary in their complexity and the type of information they can store. Some formats focus primarily on network topology, while others can preserve additional metadata such as node attributes, edge properties, visual styling, and layout information. All file types listed (except Excel) are text files and you can edit and view them in a regular text editor.
 
-<a id="sif_format"> </a>
-## SIF Format
+<a id="cytoscape_cx"> </a>
+## Cytoscape Exchange Format (CX2)
 
-The SIF format specifies nodes and interactions only, while other
-formats store additional information about network layout and allow
-network data exchange with a variety of other network programs and data
-sources. Typically, SIF files are used to import interactions when
-building a network for the first time, since they are easy to create in
-a text editor or spreadsheet. Once the interactions have been loaded and
-network layout has been performed, the network may be saved to GML or
-XGMML format for interaction with other systems.
+The Cytoscape Exchange Format version 2 (CX2) is a JSON-based network data exchange format designed for efficient interoperability across various Cytoscape ecosystem applications, including Cytoscape Desktop, Cytoscape Web, and the Network Data Exchange (NDEx). CX2 organizes network data into modular "aspects," each structured independently following its own schema. This aspect-oriented approach simplifies handling complex data such as visual styles, network topology, node and edge attributes, and layout coordinates, allowing consistent interpretation and presentation across different tools.
 
-The simple interaction format is convenient for building a graph from a
-list of interactions. It also makes it easy to combine different
-interaction sets into a larger network, or add new interactions to an
-existing data set. The main disadvantage is that this format does not
-include any layout information, forcing Cytoscape to re-compute a new
-layout of the network each time it is loaded.
+Originally introduced as an evolution of the Cytoscape Exchange (CX) format, CX2 was collaboratively developed by the Cytoscape and NDEx teams to better support the increasing complexity of biological networks and their associated metadata. CX2 enhances performance through a compact design optimized for web applications, reducing memory usage and improving network data transfer efficiency. Its extensible structure enables easy incorporation of new features without impacting existing compatibility, supporting future advancements within the Cytoscape community.
 
-Lines in the SIF file specify a source node, a relationship type (or
-edge type), and one or more target nodes:
+A simple CX2 network example with two nodes, one edge, attributes, and layout coordinates is shown below:
 
-    nodeA relationship_type nodeB
-    nodeC relationship_type nodeA
-    nodeD relationship_type nodeE nodeF nodeB
-    nodeG
-    ...
-    nodeY relationship_type nodeZ
+```json
+[
+  {
+    "CXVersion": "2.0",
+    "hasFragments": false
+  },
+  {
+    "attributeDeclarations": [
+      {
+        "networkAttributes": {
+          "name": {"d": "string"}
+        },
+        "nodes": {
+          "name": {"d": "string"},
+          "type": {"d": "string"}
+        },
+        "edges": {
+          "interaction": {"d": "string"}
+        }
+      }
+    ]
+  },
+  {
+    "networkAttributes": [
+      {"name": "Simple Network Example"}
+    ]
+  },
+  {
+    "nodes": [
+      {"id": 1, "x": 100, "y": 200, "v": {"name": "Node A", "type": "protein"}},
+      {"id": 2, "x": 300, "y": 400, "v": {"name": "Node B", "type": "protein"}}
+    ]
+  },
+  {
+    "edges": [
+      {"id": 100, "s": 1, "t": 2, "v": {"interaction": "binds"}}
+    ]
+  },
+  {
+    "status": [
+      {"error": "", "success": true}
+    ]
+  }
+]
+```
 
-A more specific example is:
-
-    node1 typeA node2
-    node2 typeB node3 node4 node5
-    node0
-
-The first line identifies two nodes, called node1 and node2, and a
-single relationship between node1 and node2 of type typeA. The second
-line specifies three new nodes, node3, node4, and node5; here "node2"
-refers to the same node as in the first line. The second line also
-specifies three relationships, all of type typeB and with node2 as the
-source, with node3, node4, and node5 as the targets. This second form is
-simply shorthand for specifying multiple relationships of the same type
-with the same source node. The third line indicates how to specify a
-node that has no relationships with other nodes. This form is not needed
-for nodes that do have relationships, since the specification of the
-relationship implicitly identifies the nodes as well.
-
-Duplicate entries are preserved. Multiple edges between the same nodes
-can have identical edge types. For example, the following specifies three
-edges between the same pair of nodes, two of type xx and one of type yy:
-
-    node1 xx node2
-    node1 xx node2
-    node1 yy node2
-
-Edges connecting a node to itself (self-edges) are also allowed:
-
-    node1 xx node1
-
-Every node and edge in Cytoscape has a name column. For a network
-defined in SIF format, node names should be unique, as identically named
-nodes will be treated as identical nodes. The name of each node will be
-the name in this file by default (unless another string is mapped to
-display on the node using styles). This is discussed in the section on
-**[Styles](Styles.md)**.
-The name of each edge will be formed from the name of the source and
-target nodes plus the interaction type: for example,
-`sourceName (edgeType) targetName`.
-
-The tag "edgeType" can be any string. Whole words or concatenated
-words may be used to define types of relationships, e.g. geneFusion,
-cogInference, pullsDown, activates, degrades, inactivates, inhibits,
-phosphorylates, upRegulates, etc.
-
-Some common interaction types used in the Systems Biology community are
-as follows:
-
-      pp .................. protein - protein interaction
-      pd .................. protein -> DNA
-      (e.g. transcription factor binding upstream of a regulating gene.)
-
-Some less common interaction types used are:
-
-      pr .................. protein -> reaction
-      rc .................. reaction -> compound
-      cr .................. compound -> reaction
-      gl .................. genetic lethal relationship
-      pm .................. protein-metabolite interaction
-      mp .................. metabolite-protein interaction
-
-<a id="delimiters"> </a>
-### Delimiters
-
-Whitespace (space or tab) is used to delimit the names in the simple
-interaction file format. However, in some cases spaces are desired in a
-node name or edge type. The standard is that, if the file contains any
-tab characters, then tabs are used to delimit the fields and spaces are
-considered part of the name. If the file contains no tabs, then any
-spaces are delimiters that separate names (and names cannot contain
-spaces).
-
-If your network unexpectedly contains no edges and node names that look
-like edge names, it probably means your file contains a stray tab that's
-fooling the parser. On the other hand, if your network has nodes whose
-names are half of a full name, then you probably meant to use tabs to
-separate node names with spaces.
-
-Networks in simple interactions format are often stored in files with a
-`.sif` extension, and Cytoscape recognizes this extension when browsing
-a directory for files of this type.
-
-<a id="gml_format"> </a>	
-## GML Format
-
-In contrast to SIF, GML is a rich graph format language supported by
-many other network visualization packages. The GML file format
-specification is available at:
-
-[http://graphviewer.nl/misc/gmllanguage/gml-technical-report.pdf](http://www.graphviewer.nl/misc/gmllanguage/gml-technical-report.pdf)
-
-It is generally not necessary to modify the content of a GML file
-directly. Once a network is built in SIF format and then laid out, the
-layout is preserved by saving to and loading from GML. Properties
-specified in a GML file will result in a new style named
-`Filename.style` when that GML file is loaded.
-
-<a id="xgmml_format"> </a>
-## XGMML Format
-
-XGMML is the XML evolution of GML and is based on the GML definition. In
-addition to network data, XGMML contains node/edge/network column data. More
-information on Wikipedia:
-
-[https://en.wikipedia.org/wiki/XGMML](https://en.wikipedia.org/wiki/XGMML)
-
-XGMML is now preferred to GML because it offers the flexibility
-associated with all XML document types. If you're unsure about which to
-use, choose XGMML.
-
-There is a java system property "cytoscape.xgmml.repair.bare.ampersands"
-that can be set to "true" if you have experience trouble reading older
-files.
-
-This should only be used when an XGMML file or session cannot be read
-due improperly encoded ampersands, as it slows down the reading process,
-but this is still preferable to attempting to fix such files using
-manual editing.
-
-<a id="sbml_systems_biology_markup_language_format"> </a>
-## SBML (Systems Biology Markup Language) Format
-
-The Systems Biology Markup Language (SBML) is an XML format to describe
-biochemical networks. SBML file format specification is available at:
-
-[http://sbml.org/documents/](http://sbml.org/documents/)
-
-<a id="biopax_biological_pathways_exchange_format"> </a>
-## BioPAX (Biological PAthways eXchange) Format
-
-BioPAX is an OWL (Web Ontology Language) document designed to exchange
-biological pathways data. The complete set of documents for this format
-is available at:
-
-[http://www.biopax.org/](http://www.biopax.org/)
-
-<a id="graphml"> </a>
-## GraphML
-
-GraphML is a comprehensive and easy-to-use file format for graphs. It is
-based on XML. The complete set of documents for this format is available
-at:
-
-[http://graphml.graphdrawing.org/](http://graphml.graphdrawing.org/)
-
-<a id="delimited_text_table_and_excel_workbook"> </a>
-## Delimited Text Table and Excel Workbook
-
-Cytoscape has native support for Microsoft Excel files (.xls, .xlsx) and
-delimited text files. The tables in these files can have network data
-and edge columns. Users can specify columns containg source nodes,
-target nodes, interaction types, and edge columns during file import.
-Some of the other network analysis tools, such as igraph
-([https://igraph.org/](https://igraph.org/)), has feature to export graph
-as simple text files. Cytoscape can read these text files and build
-networks from them. For more detail, please read the Import Free-Format
-Tables section of the **[Creating
-Networks](Creating_Networks.md#creating-networks)**
-section.
+For detailed information about the CX2 specification, supported aspects, and additional examples, please visit the [Cytoscape Exchange Format documentation](https://cytoscape.org/cx/cx2/specification/cytoscape-exchange-format-specification-%28version-2%29/).
 
 <a id="cytoscape_js_json"> </a>
 ## Cytoscape.js JSON
@@ -425,61 +294,192 @@ JSON file **WITHOUT** style. This means that you need to export the
 style in a separate JSON file if you apply style to your network. Please
 read the [Style](Styles.md#styles) section for more details.
 
-<a id="cytoscape_cx"> </a>
-## Cytoscape Exchange Format (CX2)
+<a id="sif_format"> </a>
+## SIF Format
 
-The Cytoscape Exchange Format version 2 (CX2) is a JSON-based network data exchange format designed for efficient interoperability across various Cytoscape ecosystem applications, including Cytoscape Desktop, Cytoscape Web, and the Network Data Exchange (NDEx). CX2 organizes network data into modular "aspects," each structured independently following its own schema. This aspect-oriented approach simplifies handling complex data such as visual styles, network topology, node and edge attributes, and layout coordinates, allowing consistent interpretation and presentation across different tools.
+The SIF format specifies nodes and interactions only, while other
+formats store additional information about network layout and allow
+network data exchange with a variety of other network programs and data
+sources. Typically, SIF files are used to import interactions when
+building a network for the first time, since they are easy to create in
+a text editor or spreadsheet. Once the interactions have been loaded and
+network layout has been performed, the network may be saved to GML or
+XGMML format for interaction with other systems.
 
-Originally introduced as an evolution of the Cytoscape Exchange (CX) format, CX2 was collaboratively developed by the Cytoscape and NDEx teams to better support the increasing complexity of biological networks and their associated metadata. CX2 enhances performance through a compact design optimized for web applications, reducing memory usage and improving network data transfer efficiency. Its extensible structure enables easy incorporation of new features without impacting existing compatibility, supporting future advancements within the Cytoscape community.
+The simple interaction format is convenient for building a graph from a
+list of interactions. It also makes it easy to combine different
+interaction sets into a larger network, or add new interactions to an
+existing data set. The main disadvantage is that this format does not
+include any layout information, forcing Cytoscape to re-compute a new
+layout of the network each time it is loaded.
 
-A simple CX2 network example with two nodes, one edge, attributes, and layout coordinates is shown below:
+Lines in the SIF file specify a source node, a relationship type (or
+edge type), and one or more target nodes:
 
-```json
-[
-  {
-    "CXVersion": "2.0",
-    "hasFragments": false
-  },
-  {
-    "attributeDeclarations": [
-      {
-        "networkAttributes": {
-          "name": {"d": "string"}
-        },
-        "nodes": {
-          "name": {"d": "string"},
-          "type": {"d": "string"}
-        },
-        "edges": {
-          "interaction": {"d": "string"}
-        }
-      }
-    ]
-  },
-  {
-    "networkAttributes": [
-      {"name": "Simple Network Example"}
-    ]
-  },
-  {
-    "nodes": [
-      {"id": 1, "x": 100, "y": 200, "v": {"name": "Node A", "type": "protein"}},
-      {"id": 2, "x": 300, "y": 400, "v": {"name": "Node B", "type": "protein"}}
-    ]
-  },
-  {
-    "edges": [
-      {"id": 100, "s": 1, "t": 2, "v": {"interaction": "binds"}}
-    ]
-  },
-  {
-    "status": [
-      {"error": "", "success": true}
-    ]
-  }
-]
-```
+    nodeA relationship_type nodeB
+    nodeC relationship_type nodeA
+    nodeD relationship_type nodeE nodeF nodeB
+    nodeG
+    ...
+    nodeY relationship_type nodeZ
 
-For detailed information about the CX2 specification, supported aspects, and additional examples, please visit the [Cytoscape Exchange Format documentation](https://cytoscape.org/cx/cx2/specification/cytoscape-exchange-format-specification-%28version-2%29/).
+A more specific example is:
 
+    node1 typeA node2
+    node2 typeB node3 node4 node5
+    node0
+
+The first line identifies two nodes, called node1 and node2, and a
+single relationship between node1 and node2 of type typeA. The second
+line specifies three new nodes, node3, node4, and node5; here "node2"
+refers to the same node as in the first line. The second line also
+specifies three relationships, all of type typeB and with node2 as the
+source, with node3, node4, and node5 as the targets. This second form is
+simply shorthand for specifying multiple relationships of the same type
+with the same source node. The third line indicates how to specify a
+node that has no relationships with other nodes. This form is not needed
+for nodes that do have relationships, since the specification of the
+relationship implicitly identifies the nodes as well.
+
+Duplicate entries are preserved. Multiple edges between the same nodes
+can have identical edge types. For example, the following specifies three
+edges between the same pair of nodes, two of type xx and one of type yy:
+
+    node1 xx node2
+    node1 xx node2
+    node1 yy node2
+
+Edges connecting a node to itself (self-edges) are also allowed:
+
+    node1 xx node1
+
+Every node and edge in Cytoscape has a name column. For a network
+defined in SIF format, node names should be unique, as identically named
+nodes will be treated as identical nodes. The name of each node will be
+the name in this file by default (unless another string is mapped to
+display on the node using styles). This is discussed in the section on
+**[Styles](Styles.md)**.
+The name of each edge will be formed from the name of the source and
+target nodes plus the interaction type: for example,
+`sourceName (edgeType) targetName`.
+
+The tag "edgeType" can be any string. Whole words or concatenated
+words may be used to define types of relationships, e.g. geneFusion,
+cogInference, pullsDown, activates, degrades, inactivates, inhibits,
+phosphorylates, upRegulates, etc.
+
+Some common interaction types used in the Systems Biology community are
+as follows:
+
+      pp .................. protein - protein interaction
+      pd .................. protein -> DNA
+      (e.g. transcription factor binding upstream of a regulating gene.)
+
+Some less common interaction types used are:
+
+      pr .................. protein -> reaction
+      rc .................. reaction -> compound
+      cr .................. compound -> reaction
+      gl .................. genetic lethal relationship
+      pm .................. protein-metabolite interaction
+      mp .................. metabolite-protein interaction
+
+<a id="delimiters"> </a>
+### Delimiters
+
+Whitespace (space or tab) is used to delimit the names in the simple
+interaction file format. However, in some cases spaces are desired in a
+node name or edge type. The standard is that, if the file contains any
+tab characters, then tabs are used to delimit the fields and spaces are
+considered part of the name. If the file contains no tabs, then any
+spaces are delimiters that separate names (and names cannot contain
+spaces).
+
+If your network unexpectedly contains no edges and node names that look
+like edge names, it probably means your file contains a stray tab that's
+fooling the parser. On the other hand, if your network has nodes whose
+names are half of a full name, then you probably meant to use tabs to
+separate node names with spaces.
+
+Networks in simple interactions format are often stored in files with a
+`.sif` extension, and Cytoscape recognizes this extension when browsing
+a directory for files of this type.
+
+<a id="gml_format"> </a>	
+## GML Format
+
+In contrast to SIF, GML is a rich graph format language supported by
+many other network visualization packages. The GML file format
+specification is available at:
+
+[http://graphviewer.nl/misc/gmllanguage/gml-technical-report.pdf](http://www.graphviewer.nl/misc/gmllanguage/gml-technical-report.pdf)
+
+It is generally not necessary to modify the content of a GML file
+directly. Once a network is built in SIF format and then laid out, the
+layout is preserved by saving to and loading from GML. Properties
+specified in a GML file will result in a new style named
+`Filename.style` when that GML file is loaded.
+
+<a id="xgmml_format"> </a>
+## XGMML Format
+
+XGMML is the XML evolution of GML and is based on the GML definition. In
+addition to network data, XGMML contains node/edge/network column data. More
+information on Wikipedia:
+
+[https://en.wikipedia.org/wiki/XGMML](https://en.wikipedia.org/wiki/XGMML)
+
+XGMML is now preferred to GML because it offers the flexibility
+associated with all XML document types. If you're unsure about which to
+use, choose XGMML.
+
+There is a java system property "cytoscape.xgmml.repair.bare.ampersands"
+that can be set to "true" if you have experience trouble reading older
+files.
+
+This should only be used when an XGMML file or session cannot be read
+due improperly encoded ampersands, as it slows down the reading process,
+but this is still preferable to attempting to fix such files using
+manual editing.
+
+<a id="sbml_systems_biology_markup_language_format"> </a>
+## SBML (Systems Biology Markup Language) Format
+
+The Systems Biology Markup Language (SBML) is an XML format to describe
+biochemical networks. SBML file format specification is available at:
+
+[http://sbml.org/documents/](http://sbml.org/documents/)
+
+<a id="biopax_biological_pathways_exchange_format"> </a>
+## BioPAX (Biological PAthways eXchange) Format
+
+BioPAX is an OWL (Web Ontology Language) document designed to exchange
+biological pathways data. The complete set of documents for this format
+is available at:
+
+[http://www.biopax.org/](http://www.biopax.org/)
+
+<a id="graphml"> </a>
+## GraphML
+
+GraphML is a comprehensive and easy-to-use file format for graphs. It is
+based on XML. The complete set of documents for this format is available
+at:
+
+[http://graphml.graphdrawing.org/](http://graphml.graphdrawing.org/)
+
+<a id="delimited_text_table_and_excel_workbook"> </a>
+## Delimited Text Table and Excel Workbook
+
+Cytoscape has native support for Microsoft Excel files (.xls, .xlsx) and
+delimited text files. The tables in these files can have network data
+and edge columns. Users can specify columns containg source nodes,
+target nodes, interaction types, and edge columns during file import.
+Some of the other network analysis tools, such as igraph
+([https://igraph.org/](https://igraph.org/)), has feature to export graph
+as simple text files. Cytoscape can read these text files and build
+networks from them. For more detail, please read the Import Free-Format
+Tables section of the **[Creating
+Networks](Creating_Networks.md#creating-networks)**
+section.
 

--- a/docs/Supported_Network_File_Formats.md
+++ b/docs/Supported_Network_File_Formats.md
@@ -1,6 +1,8 @@
 <a id="supported_network_file_formats"> </a>
 # Supported Network File Formats
 
+Cytoscape represents networks as directed graphs, where nodes represent entities (such as genes, proteins, or metabolites) and edges represent relationships or interactions between these entities. All edges in Cytoscape are inherently directed, meaning they have a source node and a target node. However, Cytoscape does not interpret or assign semantic meaning to the imported graph structure - it simply preserves the topological relationships as specified in the input data. The biological or functional significance of nodes and edges is determined by the user's interpretation and analysis.
+
 Cytoscape can read network/pathway files written in the following
 formats:
 
@@ -23,7 +25,12 @@ formats:
 -   [Cytoscape.js
     JSON](http://cytoscape.github.io/cytoscape.js/#notation/elements-json)
     
--   [Cytoscape CX](https://github.com/CyComponent/CyWiki)    
+-   Cytoscape Exchange Format (CX2)    
+
+These formats vary in their complexity and the type of information they can store. Some formats focus primarily on network topology, while others can preserve additional metadata such as node attributes, edge properties, visual styling, and layout information. All file types listed (except Excel) are text files and you can edit and view them in a regular text editor.
+
+<a id="sif_format"> </a>
+## SIF Format
 
 The SIF format specifies nodes and interactions only, while other
 formats store additional information about network layout and allow
@@ -32,12 +39,7 @@ sources. Typically, SIF files are used to import interactions when
 building a network for the first time, since they are easy to create in
 a text editor or spreadsheet. Once the interactions have been loaded and
 network layout has been performed, the network may be saved to GML or
-XGMML format for interaction with other systems. All file types listed
-(except Excel) are text files and you can edit and view them in a
-regular text editor.
-
-<a id="sif_format"> </a>
-## SIF Format
+XGMML format for interaction with other systems.
 
 The simple interaction format is convenient for building a graph from a
 list of interactions. It also makes it easy to combine different
@@ -424,41 +426,62 @@ style in a separate JSON file if you apply style to your network. Please
 read the [Style](Styles.md#styles) section for more details.
 
 <a id="cytoscape_cx"> </a>
-## Cytoscape CX
+## Cytoscape Exchange Format (CX2)
 
-CX is a JSON-based transfer format that enables diverse Cytoscape Cyberinfrastructure (CI) services to exchange networks while preserving all network-related information.
-It is designed for flexibility, modularity, and extensibility, and as a message payload in common CI REST protocols. It enables applications to standardize on core aspects of networks, coordinate on more specific or unique standards, and to ignore or omit irrelevant aspects. It is not intended as an optimized format for storage or for specific functionality in applications.
- 
-CX is an Aspect-Oriented Network Interchange Format, where the base information is a list of nodes. Independent data structures (called aspects) organize and elaborate on nodes and each other. The core of CX defines five aspects, though a more comprehensive [CX document](https://github.com/CyComponent/CyWiki) describes many more aspects.
+## Cytoscape Exchange Format (CX2)
 
-<table cellspacing="0" style="table-layout: fixed; width: 700px">
-<colgroup> <col style="width:200px">                              <col style="width:500px"> </colgroup>
-<tbody>
-<tr> <th>Aspect</th>                                 <th>Purpose</th></tr>
-<tr> <th class="spec ulcase">networkAttributes</th>  <td class="">element specify name-value pairs describing the network</td> </tr>
-<tr> <th class="specalt ulcase">nodes</th>           <td class="alt">elements specify the identifiers for nodes in a network, optionally specifying a node name</td> </tr>
-<tr> <th class="spec ulcase">edges</th>              <td class="">elements specify edges that connect nodes, optionally specifying a interaction</td> </tr>
-<tr> <th class="specalt ulcase">nodeAttributes</th>  <td class="alt">elements specify name-value pairs describing nodes</td> </tr>
-<tr> <th class="spec ulcase">edgeAttributes</th>     <td class="">elements specify name-value pairs describing edges</td> </tr>
-</tbody>
-</table>
-<br>
+The Cytoscape Exchange Format version 2 (CX2) is a JSON-based network data exchange format designed for efficient interoperability across various Cytoscape ecosystem applications, including Cytoscape Desktop, Cytoscape Web, and the Network Data Exchange (NDEx). CX2 organizes network data into modular "aspects," each structured independently following its own schema. This aspect-oriented approach simplifies handling complex data such as visual styles, network topology, node and edge attributes, and layout coordinates, allowing consistent interpretation and presentation across different tools.
 
-The **nodes** aspect contains only the identifiers of the network's nodes, The **edges** aspect contains identifiers for each edge along with the identifiers of the nodes the edge connects. The **networkAttributes** aspect contains name-value pairs describing the network. The **nodeAttributes** and "edgeAttributes" aspects contain name-value pairs attached to specifically identified nodes and edges.
+Originally introduced as an evolution of the Cytoscape Exchange (CX) format, CX2 was collaboratively developed by the Cytoscape and NDEx teams to better support the increasing complexity of biological networks and their associated metadata. CX2 enhances performance through a compact design optimized for web applications, reducing memory usage and improving network data transfer efficiency. Its extensible structure enables easy incorporation of new features without impacting existing compatibility, supporting future advancements within the Cytoscape community.
 
-Critically, applications are free to add and maintain their own aspects without coordinating or negotiating with disinterested applications.
+A simple CX2 network example with two nodes, one edge, attributes, and layout coordinates is shown below:
 
-As an illustration using the picture below, a three node network can be described as a list of nodes (**nodes** aspect) and edges that link them (**edges** aspect). If the network has been laid out, a separate aspect (**cartesianLayout** aspect) can describe the position of each node. More concretely, a CX encoding would have three nodes in the **nodes** aspect, each with unique IDs. The **edges** aspect references each node by ID, with each edge having its own ID. Finally, the **cartesianLayout** aspect ties coordinates to nodes by ID. In fact, a network may have many aspects, describing node and edge attributes, subnetworks, visual properties, groups and so on.
+```json
+[
+  {
+    "CXVersion": "2.0",
+    "hasFragments": false
+  },
+  {
+    "attributeDeclarations": [
+      {
+        "networkAttributes": {
+          "name": {"d": "string"}
+        },
+        "nodes": {
+          "name": {"d": "string"},
+          "type": {"d": "string"}
+        },
+        "edges": {
+          "interaction": {"d": "string"}
+        }
+      }
+    ]
+  },
+  {
+    "networkAttributes": [
+      {"name": "Simple Network Example"}
+    ]
+  },
+  {
+    "nodes": [
+      {"id": 1, "x": 100, "y": 200, "v": {"name": "Node A", "type": "protein"}},
+      {"id": 2, "x": 300, "y": 400, "v": {"name": "Node B", "type": "protein"}}
+    ]
+  },
+  {
+    "edges": [
+      {"id": 100, "s": 1, "t": 2, "v": {"interaction": "binds"}}
+    ]
+  },
+  {
+    "status": [
+      {"error": "", "success": true}
+    ]
+  }
+]
+```
 
-![](_static/images/Network_Formats/cx_example.png)
+For detailed information about the CX2 specification, supported aspects, and additional examples, please visit the [Cytoscape Exchange Format documentation](https://cytoscape.org/cx/cx2/specification/cytoscape-exchange-format-specification-%28version-2%29/).
 
-The actual JSON encoding for a CX stream is described in the [CX document](https://github.com/CyComponent/CyWiki). It would appear something like this: 
 
-    {
-      "nodes": [{"@id": 1}, {"@id": 2}, {"@id": 3}],
-      "edges": [{"s": 1, "@id": 4, "t": 2}, 
-                {"s": 2, "@id": 5, "t": 3}],
-      "cartesianLayout": [{"x": 100, "node": 1, "y": 100}, 
-                          {"x": 200, "node": 2, "y": 200},
-                          {"x": 100, "node": 3, "y": 200}]
-    }

--- a/docs/Supported_Network_File_Formats.md
+++ b/docs/Supported_Network_File_Formats.md
@@ -428,8 +428,6 @@ read the [Style](Styles.md#styles) section for more details.
 <a id="cytoscape_cx"> </a>
 ## Cytoscape Exchange Format (CX2)
 
-## Cytoscape Exchange Format (CX2)
-
 The Cytoscape Exchange Format version 2 (CX2) is a JSON-based network data exchange format designed for efficient interoperability across various Cytoscape ecosystem applications, including Cytoscape Desktop, Cytoscape Web, and the Network Data Exchange (NDEx). CX2 organizes network data into modular "aspects," each structured independently following its own schema. This aspect-oriented approach simplifies handling complex data such as visual styles, network topology, node and edge attributes, and layout coordinates, allowing consistent interpretation and presentation across different tools.
 
 Originally introduced as an evolution of the Cytoscape Exchange (CX) format, CX2 was collaboratively developed by the Cytoscape and NDEx teams to better support the increasing complexity of biological networks and their associated metadata. CX2 enhances performance through a compact design optimized for web applications, reducing memory usage and improving network data transfer efficiency. Its extensible structure enables easy incorporation of new features without impacting existing compatibility, supporting future advancements within the Cytoscape community.

--- a/docs/Supported_Network_File_Formats.md
+++ b/docs/Supported_Network_File_Formats.md
@@ -473,7 +473,7 @@ at:
 
 Cytoscape has native support for Microsoft Excel files (.xls, .xlsx) and
 delimited text files. The tables in these files can have network data
-and edge columns. Users can specify columns containg source nodes,
+and edge columns. Users can specify columns containing source nodes,
 target nodes, interaction types, and edge columns during file import.
 Some of the other network analysis tools, such as igraph
 ([https://igraph.org/](https://igraph.org/)), has feature to export graph

--- a/docs/Supported_Network_File_Formats.md
+++ b/docs/Supported_Network_File_Formats.md
@@ -74,8 +74,8 @@ node that has no relationships with other nodes. This form is not needed
 for nodes that do have relationships, since the specification of the
 relationship implicitly identifies the nodes as well.
 
-Duplicate entries are kept. Multiple edges between the same nodes
-can have the same edge types. For example, the following specifies three
+Duplicate entries are preserved. Multiple edges between the same nodes
+can have identical edge types. For example, the following specifies three
 edges between the same pair of nodes, two of type xx and one of type yy:
 
     node1 xx node2


### PR DESCRIPTION
Clarified the graph model documentation in Cytoscape. Corrected the explanation of how the SIF importer handles duplicate entries. Updated the CX section and moved it to the top of the page for better visibility.